### PR TITLE
Rename contract to the intended name in the filename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ out/
 cache/
 node_modules/
 .env
+fuse-flywheel.iml

--- a/src/rewards/FuseFlywheelRewardsPlugin.sol
+++ b/src/rewards/FuseFlywheelRewardsPlugin.sol
@@ -19,7 +19,7 @@ interface IERC4626 {
  @notice Determines rewards based on how many reward tokens appeared in the market itself since last accrual.
  All rewards are claimed atomically, so there is no need to use the last reward timestamp.
 */
-contract FuseFlywheelDynamicRewards is IFlywheelRewards {
+contract FuseFlywheelRewardsPlugin is IFlywheelRewards {
     using SafeTransferLib for ERC20;
 
     event Log(string message);


### PR DESCRIPTION
FuseFlywheelDynamicRewards is defined twice due to mismanaged copy-paste of a file. The most probable intended name is `FuseFlywheelRewardsPlugin` as the matching filename